### PR TITLE
Fixed merge conflict in client-list.po.ts

### DIFF
--- a/NGTrackForce/e2e/client-list/client-list.po.ts
+++ b/NGTrackForce/e2e/client-list/client-list.po.ts
@@ -73,13 +73,8 @@ export class ClientListPo extends BasePage {
     /**
      * Returns the search by client name element in the DOM
      */
-<<<<<<< Updated upstream
     private getSearchByClientName(){
         return this.clientSearch;
-=======
-    private getSearchByClientName() {
-        return element(by.id('["clientSearch"]'));
->>>>>>> Stashed changes
     }
 
     /**


### PR DESCRIPTION
Changes made in the old fork left a merge conflict in one of the protractor POMs that broke the protractor tests. I removed the changes we made, preferring the more abstracted version from upstream.