### PR TITLE
Made jacoco-prepare-agent run tests locally.

### DIFF
--- a/TrackForce/pom.xml
+++ b/TrackForce/pom.xml
@@ -227,15 +227,15 @@
 					<!-- change this n the properties at the top of the pom -->
 					<skipTests>${skip.unit.tests}</skipTests>
 					<!-- Excludes integration tests when unit tests are run. -->
-					<excludes>
-						<exclude>**/IT*.java</exclude>
-						<exclude>com/revature/test/admin/cukes/*.java</exclude>
-						<exclude>com/revature/test/admin/pom/*.java</exclude>
-					</excludes>
+					<!--<excludes>-->
+						<!--<exclude>**/IT*.java</exclude>-->
+						<!--<exclude>com/revature/test/admin/cukes/*.java</exclude>-->
+						<!--<exclude>com/revature/test/admin/pom/*.java</exclude>-->
+					<!--</excludes>-->
 
-					<suiteXmlFiles>
-						<file>src/test/resources/surefire_test.xml</file>
-					</suiteXmlFiles>
+					<!--<suiteXmlFiles>-->
+						<!--<file>src/test/resources/surefire_test.xml</file>-->
+					<!--</suiteXmlFiles>-->
 					<properties>
 						<property>
 							<name>suitethreadpoolsize</name>

--- a/TrackForce/src/test/java/com/revature/test/dao/DbUnit.java
+++ b/TrackForce/src/test/java/com/revature/test/dao/DbUnit.java
@@ -37,10 +37,10 @@ public class DbUnit extends JdbcBasedDBTestCase{
    //hardcoded location for xml file storing front-end data
     @Override
     protected IDataSet getDataSet() throws Exception {
-       String filePath ="/TrackForce/src/test/java/com/revature/test/dao/DbUnitDataset.xml";
+       String filePath ="src/test/java/com/revature/test/dao/DbUnitDataset.xml";
        //  return new XmlDataSet(this.getClass().getClassLoader()
 		//		.getResourceAsStream("DbUnitDataset.xml"));
-    	IDataSet data = new XmlDataSet(new FileInputStream(new File("C:\\my_git_repos\\trackforce\\TrackForce\\src\\test\\java\\com\\revature\\test\\dao\\DbUnitDataset.xml")));
+    	IDataSet data = new XmlDataSet(new FileInputStream(new File(filePath)));
     	
         return data;
     }


### PR DESCRIPTION
Jacoco is a tool that we're using to run tests and get code coverage for SonarQube, and it's not been running. I ran Jacoco explicitly and discovered that it was looking for an XML file that doesn't exist, and that it was also ignoring some files explicitly, so I commented out those lines to see what happened, and it ran at least the DBUnit test. I'm merging this into dev to test to see if that functionality will properly fix running it as part of the build.