### PR TITLE
Started transition to Cobertura

### DIFF
--- a/TrackForce/pom.xml
+++ b/TrackForce/pom.xml
@@ -189,22 +189,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.1</version>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/org.jacoco/org.jacoco.agent -->
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>org.jacoco.agent</artifactId>
-			<version>0.8.1</version>
-		</dependency>
-
-
-
 		<!-- https://mvnrepository.com/artifact/io.swagger/swagger-jersey2-jaxrs -->
 		<dependency>
 			<groupId>io.swagger</groupId>

--- a/TrackForce/pom.xml
+++ b/TrackForce/pom.xml
@@ -241,6 +241,74 @@
 	<!-- William added the below tags on 2/15/18 so that the main application 
 		can be successfully deployed -->
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20</version>
+				<configuration>
+					<forkCount>0</forkCount>
+					<!-- Skips unit tests if the value of skip.unit.tests property is true -->
+					<!-- William changed the value of skipTests to true on 2/15/18 -->
+					<!-- to see if we can successfully deploy current build of application -->
+					<!-- change this n the properties at the top of the pom -->
+					<skipTests>${skip.unit.tests}</skipTests>
+					<!-- Excludes integration tests when unit tests are run. -->
+					<excludes>
+						<exclude>**/IT*.java</exclude>
+						<exclude>com/revature/test/admin/cukes/*.java</exclude>
+						<exclude>com/revature/test/admin/pom/*.java</exclude>
+					</excludes>
+
+					<!--<suiteXmlFiles>-->
+					<!--<file>src/test/resources/surefire_test.xml</file>-->
+					<!--</suiteXmlFiles>-->
+					<properties>
+						<property>
+							<name>suitethreadpoolsize</name>
+							<value>1</value>
+						</property>
+						<property>
+							<name>surefire.testng.verbose</name>
+							<value>0</value>
+						</property>
+					</properties>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.20</version>
+				<executions>
+					<!-- Ensures that both integration-test and verify goals of the Failsafe
+						Maven plugin are executed. -->
+					<execution>
+						<id>integration-tests</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<forkCount>0</forkCount>
+							<!--Skips integration tests if the value of skip.integration.tests
+								property is true -->
+							<!-- Skips unit tests if the value of skip.unit.tests property is
+								true -->
+							<!-- William changed the value of skipTests to true on 2/15/18 -->
+							<!-- to see if we can successfully deploy current build of application -->
+							<!-- change this n the properties at the top of the pom -->
+							<skipTests>${skip.integration.tests}</skipTests>
+							<excludes>
+								<exclude>com/revature/test/admin/cukes/*.java</exclude>
+								<exclude>com/revature/test/admin/pom/*.java</exclude>
+							</excludes>
+						</configuration>
+
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 	<reporting>
 		<plugins>

--- a/TrackForce/pom.xml
+++ b/TrackForce/pom.xml
@@ -193,8 +193,17 @@
 		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.0</version>
+			<version>0.8.1</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.jacoco/org.jacoco.agent -->
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.agent</artifactId>
+			<version>0.8.1</version>
+		</dependency>
+
+
 
 		<!-- https://mvnrepository.com/artifact/io.swagger/swagger-jersey2-jaxrs -->
 		<dependency>
@@ -236,148 +245,32 @@
 			<version>1.1.1</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>cobertura-maven-plugin</artifactId>
+			<version>2.7</version>
+
+		</dependency>
+
 	</dependencies>
 
 	<!-- William added the below tags on 2/15/18 so that the main application 
 		can be successfully deployed -->
 	<build>
+	</build>
+	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20</version>
-				<configuration>
-					<forkCount>0</forkCount>
-					<!-- Skips unit tests if the value of skip.unit.tests property is true -->
-					<!-- William changed the value of skipTests to true on 2/15/18 -->
-					<!-- to see if we can successfully deploy current build of application -->
-					<!-- change this n the properties at the top of the pom -->
-					<skipTests>${skip.unit.tests}</skipTests>
-					<!-- Excludes integration tests when unit tests are run. -->
-					<!--<excludes>-->
-						<!--<exclude>**/IT*.java</exclude>-->
-						<!--<exclude>com/revature/test/admin/cukes/*.java</exclude>-->
-						<!--<exclude>com/revature/test/admin/pom/*.java</exclude>-->
-					<!--</excludes>-->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
 
-					<!--<suiteXmlFiles>-->
-						<!--<file>src/test/resources/surefire_test.xml</file>-->
-					<!--</suiteXmlFiles>-->
-					<properties>
-						<property>
-							<name>suitethreadpoolsize</name>
-							<value>1</value>
-						</property>
-						<property>
-							<name>surefire.testng.verbose</name>
-							<value>0</value>
-						</property>
-					</properties>
+				<configuration>
+					<formats>
+						<format>xml</format>
+					</formats>
 				</configuration>
 			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.20</version>
-				<executions>
-					<!-- Ensures that both integration-test and verify goals of the Failsafe 
-						Maven plugin are executed. -->
-					<execution>
-						<id>integration-tests</id>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-						<configuration>
-							<forkCount>0</forkCount>
-							<!--Skips integration tests if the value of skip.integration.tests 
-								property is true -->
-							<!-- Skips unit tests if the value of skip.unit.tests property is 
-								true -->
-							<!-- William changed the value of skipTests to true on 2/15/18 -->
-							<!-- to see if we can successfully deploy current build of application -->
-							<!-- change this n the properties at the top of the pom -->
-							<skipTests>${skip.integration.tests}</skipTests>
-							<excludes>
-								<exclude>com/revature/test/admin/cukes/*.java</exclude>
-								<exclude>com/revature/test/admin/pom/*.java</exclude>
-							</excludes>
-						</configuration>
-
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.0</version>
-				<executions>
-					<!-- Prepares the property pointing to the JaCoCo runtime agent which 
-						is passed as VM argument when Maven the Surefire plugin is executed. -->
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-							<!-- Sets the name of the property containing the settings for JaCoCo 
-								runtime agent. -->
-							<propertyName>surefireArgLine</propertyName>
-						</configuration>
-					</execution>
-					<!-- Ensures that the code coverage report for unit tests is created 
-						after unit tests have been run. -->
-					<execution>
-						<id>post-unit-test</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-							<!-- Sets the output directory for the code coverage report. -->
-							<outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-						</configuration>
-					</execution>
-
-
-					<!-- Prepares the property pointing to the JaCoCo runtime agent which 
-						is passed as VM argument when Maven the Failsafe plugin is executed. -->
-					<execution>
-						<id>pre-integration-test</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<destFile>${project.build.directory}/coverage-reports/jacoco-it.exec</destFile>
-							<!-- Sets the name of the property containing the settings for JaCoCo 
-								runtime agent. -->
-							<propertyName>failsafeArgLine</propertyName>
-						</configuration>
-					</execution>
-					<!-- Ensures that the code coverage report for integration tests after 
-						integration tests have been run. -->
-					<execution>
-						<id>post-integration-test</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<dataFile>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFile>
-							<!-- Sets the output directory for the code coverage report. -->
-							<outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
-	</build>
+	</reporting>
 </project>


### PR DESCRIPTION
Deleted everything having to do with Jacoco. Originally I thought that Surefire and Failsafe configurations specifically had to do with Jacoco but upon further documentation diving I decided it'd be worth it to keep them in.

Also, added the Cobertura coverage plugin to maven, it's being run by a Jenkins build step.