### PR TITLE
Enabled second level caching, shuts down SessionFactory.

### DIFF
--- a/TrackForce/pom.xml
+++ b/TrackForce/pom.xml
@@ -258,6 +258,12 @@
 			<version>5.2.12.Final</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+			<version>3.4.0</version>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-c3p0 -->
 		<dependency>
 			<groupId>org.hibernate</groupId>

--- a/TrackForce/src/main/java/com/revature/application/Application.java
+++ b/TrackForce/src/main/java/com/revature/application/Application.java
@@ -3,6 +3,7 @@ package com.revature.application;
 import com.revature.entity.*;
 import com.revature.services.*;
 import com.revature.utils.PasswordStorage;
+import net.sf.ehcache.CacheManager;
 
 
 import java.sql.Timestamp;
@@ -37,8 +38,14 @@ public class Application {
 	static MarketingStatusService marketingStatusService = new MarketingStatusService();
 
 	public static void main(String[] args) throws PasswordStorage.CannotPerformOperationException {
-//
-		System.out.println(trainerService.getTrainerByUserId(60302));
+//		clientService.getClient(1);
+//		clientService.getClient(2);
+//		int size = CacheManager.ALL_CACHE_MANAGERS.get(0)
+//				.getCache("com.revature.entity.TfClient").getSize();
+//		System.out.println("cache size is" + size);
+
+
+
 //		TfUser u = new TfUser();
 //		u.setRole(5);
 //		u.setUsername("AssociateTest");

--- a/TrackForce/src/main/java/com/revature/entity/TfAssociate.java
+++ b/TrackForce/src/main/java/com/revature/entity/TfAssociate.java
@@ -247,7 +247,7 @@ public class TfAssociate implements java.io.Serializable {
 
 	@Override
 	public String toString() {
-		return "TfAssociate [id=" + id + ", user=" + user + ", batch=" + batch + ", marketingStatus=" + marketingStatus
+		return "TfAssociate [id=" + id + ", user=" + user + ", batch= Removed cuz stack overflow error+ " + "marketingStatus=" + marketingStatus
 				+ ", client=" + client + ", endClient=" + endClient + ", firstName=" + firstName + ", lastName="
 				+ lastName + ", interview=" + interview + ", placement=" + placement + ", clientStartDate="
 				+ clientStartDate + "]";

--- a/TrackForce/src/main/java/com/revature/entity/TfBatchLocation.java
+++ b/TrackForce/src/main/java/com/revature/entity/TfBatchLocation.java
@@ -135,7 +135,7 @@ public class TfBatchLocation implements java.io.Serializable {
 	@Override
 	public String toString() {
 		return "TfBatchLocation [tfBatchLocationId=" + id + ", tfBatchLocationName="
-				+ name + ", tfBatches=" + batches + "]";
+				+ name + "]";
 	}
 	
 

--- a/TrackForce/src/main/java/com/revature/entity/TfCurriculum.java
+++ b/TrackForce/src/main/java/com/revature/entity/TfCurriculum.java
@@ -89,7 +89,7 @@ public class TfCurriculum implements java.io.Serializable {
 
 	@Override
 	public String toString() {
-		return "TfCurriculum [id=" + id + ", name=" + name + ", batches=" + batches + "]";
+		return "TfCurriculum [id=" + id + ", name=" + name + ", batches= Removed cuz Recusion" +  "]";
 	}
 
 	@Override

--- a/TrackForce/src/main/java/com/revature/utils/HibernateUtil.java
+++ b/TrackForce/src/main/java/com/revature/utils/HibernateUtil.java
@@ -26,6 +26,16 @@ public class HibernateUtil {
 	private HibernateUtil() {}
 	private static SessionFactory sessionFactory = buildSessionFactory();
 
+	private static void addShutdown() {
+		Runtime.getRuntime().addShutdownHook(new Thread()
+			{
+				public void run() {
+					shutdown();
+				}
+			}
+		);
+	}
+
 	private static SessionFactory buildSessionFactory() {
 		Configuration cfg = new Configuration();
 			
@@ -33,17 +43,18 @@ public class HibernateUtil {
 		cfg.setProperty("hibernate.connection.username", System.getenv("TRACKFORCE_DB_USERNAME"));
 		cfg.setProperty("hibernate.connection.password", System.getenv("HBM_PW_ENV"));
 
+		addShutdown();
 		return cfg.configure().buildSessionFactory();
 	}
 	public static SessionFactory getSessionFactory() {
 		return sessionFactory;
 	}
 
-//	public static void shutdown() {
-//		System.out.println("Shutting down SessionFactory");
-//		getSessionFactory().close();
-//		System.out.println("SessionFactory closed");
-//	}
+	public static void shutdown() {
+		System.out.println("Shutting down SessionFactory");
+		getSessionFactory().close();
+		System.out.println("SessionFactory closed");
+	}
 
 	public static void closeSession(Session session) {
 		if (session != null) {

--- a/TrackForce/src/main/resources/hibernate.cfg.xml
+++ b/TrackForce/src/main/resources/hibernate.cfg.xml
@@ -22,21 +22,17 @@
           -->
         <property name="hibernate.connection.driver_class">oracle.jdbc.OracleDriver</property>
         <property name="hibernate.dialect">org.hibernate.dialect.Oracle12cDialect</property>
+
         <property name="hibernate.hbm2ddl.auto">validate</property>
         
         
-       	<property name="hibernate.cache.use_second_level_cache">false</property>
-       	
+       	<property name="hibernate.cache.use_second_level_cache">true</property>
+
        	<!-- Tells Hibernate which class to use for caching, exposed from the org.hibernate.ehcache dependency -->
 		<property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
 		<!-- Tells Hibernate the location of the ehcache.xml configuration file -->
 		<property name="net.sf.ehcache.configurationResourceName">/ehcache.xml</property>
-        
-        
-       	<!-- Tells Hibernate which class to use for caching, exposed from the org.hibernate.ehcache dependency -->
-		<property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
-		<!-- Tells Hibernate the location of the ehcache.xml configuration file -->
-		<property name="net.sf.ehcache.configurationResourceName">/ehcache.xml</property>
+
         
         
         <mapping class="com.revature.entity.TfAssociate"/>


### PR DESCRIPTION
SessionFactories will now be explicitly shutdown when the application is closed gracefully. If there's a -1 exit code, that's not graceful.