### PR TITLE
fixed sales and staging not being able to click bottom right graph

### DIFF
--- a/TrackForce/src/main/java/com/revature/resources/CurriculumResource.java
+++ b/TrackForce/src/main/java/com/revature/resources/CurriculumResource.java
@@ -99,7 +99,7 @@ public class CurriculumResource {
 		
 		if (payload == null) { // invalid token
 			return Response.status(Status.UNAUTHORIZED).entity(JWTService.invalidTokenBody(token)).build();
-		} else if (!payload.getId().equals("1")) { // wrong roleid
+		} else if (!(payload.getId().equals("1") || payload.getId().equals("3") || payload.getId().equals("4"))) { // wrong roleid
 			return Response.status(Status.FORBIDDEN).build();
 		} else {
 			return Response.ok(curriculumService.getUnmappedInfo(statusId)).build();

--- a/TrackForce/src/main/resources/ehcache.xml
+++ b/TrackForce/src/main/resources/ehcache.xml
@@ -13,11 +13,13 @@
     
     <!-- Logans attempt at getting ehcache working below -->
     <cache name="TrackForce"
-    eternal="false"
-    timeToIdleSeconds="30"
-    timeToLiveSeconds="30"
-    maxEntriesLocalHeap="10000"
-    statistics="true"/>
+    	maxEntriesLocalHeap="10000"
+        maxEntriesLocalDisk="1000"
+        eternal="false"
+        diskSpoolBufferSizeMB="20"
+        timeToIdleSeconds="300" timeToLiveSeconds="600"
+        memoryStoreEvictionPolicy="LFU"
+    	statistics="true"/>
     
 </ehcache>
 


### PR DESCRIPTION
if logged in as a sales manager or staging manager, they can now click the bottom right graph and not get a 403 error.