### PR TITLE
Associate Service Update

### DIFF
--- a/NGTrackForce/src/app/components/associate-list/associate-list.component.ts
+++ b/NGTrackForce/src/app/components/associate-list/associate-list.component.ts
@@ -121,7 +121,7 @@ export class AssociateListComponent implements OnInit {
     ) {
       this.canUpdate = true; // let the user update data if user is admin or manager
     }
-    // ?This is not a good idea to try to get a portion of the data then request all data this is not going 
+    // ?This is not a good idea to try to get a portion of the data then request all data this is not going
     // ?to aid performance in reality for now we will just fetch all until the request for pagination of associates is implemented
     //this.getNAssociates();
     // TODO: Offload the responsibility of triggering requests to a different service
@@ -185,10 +185,11 @@ export class AssociateListComponent implements OnInit {
         if (associate.batch && associate.batch.batchName === 'null') {
           associate.batch.batchName = 'None';
         }
+
+        this.isDataReady = true;
       }
       this.curriculums.delete('');
       this.curriculums.delete('null');
-      this.isDataReady = true;
     });
   }
 

--- a/NGTrackForce/src/app/components/associate-list/associate-list.component.ts
+++ b/NGTrackForce/src/app/components/associate-list/associate-list.component.ts
@@ -121,7 +121,10 @@ export class AssociateListComponent implements OnInit {
     ) {
       this.canUpdate = true; // let the user update data if user is admin or manager
     }
-    this.getNAssociates();
+    // ?This is not a good idea to try to get a portion of the data then request all data this is not going 
+    // ?to aid performance in reality for now we will just fetch all until the request for pagination of associates is implemented
+    //this.getNAssociates();
+    // TODO: Offload the responsibility of triggering requests to a different service
     this.getAllAssociates(); //TODO: change method to not use local storage
     this.getClientNames();
 

--- a/NGTrackForce/src/app/components/form-component/form.component.ts
+++ b/NGTrackForce/src/app/components/form-component/form.component.ts
@@ -88,6 +88,10 @@ export class FormComponent implements OnInit {
       this.id = +params['id']; // (+) converts string 'id' to a number
       this.associateService.getByAssociateId(this.id).subscribe(
         data => {
+          // TODO: Once the code is ready to use AsyncSubject Remove this check
+          if (!data.firstName) {
+            return;
+          }
           this.associate = data;
           this.getAssociateInterviews(this.associate.id);
         },

--- a/NGTrackForce/src/app/components/home/home.component.ts
+++ b/NGTrackForce/src/app/components/home/home.component.ts
@@ -96,6 +96,11 @@ export class HomeComponent implements OnInit {
   getCountForCharts() {
     this.as.getCountAssociates().subscribe(
       count => {
+        // Since the switch to the Behavior Subjects has an initial empty value
+        if (!count || count.length === 0) {
+          return;
+        }
+
         this.count = count;
         this.undeployedData[0] = this.count['counts'][0];
         this.undeployedData[1] = this.count['counts'][1];

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -36,6 +36,8 @@ export class AssociateService {
 
   private updateAssociates$: AsyncSubject<boolean> = new AsyncSubject<boolean>();
 
+  private updateAssociate$: AsyncSubject<boolean> = new AsyncSubject<boolean>();
+
   // TODO: Decide if empty strings is better or if a loading message should be put here
   // TODO: Why is there a get by user and get by associate this is two different models on backend
   // ? should one be handled by another service
@@ -60,7 +62,10 @@ export class AssociateService {
    */
   getAllAssociates(): BehaviorSubject<Associate[]> {
     const url: string = this.baseURL + '/allAssociates';
-    this.http.get<Associate[]>(url).subscribe((data: Associate[]) => this.allAssociates$.next(data));
+    this.http.get<Associate[]>(url).subscribe(
+      (data: Associate[]) => this.allAssociates$.next(data),
+      error => this.allAssociates$.error(error)
+    );
     return this.allAssociates$;
   }
 
@@ -80,7 +85,10 @@ export class AssociateService {
    */
   getCountAssociates(): BehaviorSubject<number[]> {
     const url: string = this.baseURL + '/countAssociates';
-    this.http.get<number[]>(url).subscribe((data: number[]) => this.associateCount$.next(data));
+    this.http.get<number[]>(url).subscribe(
+      (data: number[]) => this.associateCount$.next(data),
+      error => this.associateCount$.error(error)
+    );
     return this.associateCount$;
   }
 
@@ -91,7 +99,10 @@ export class AssociateService {
    */
   getAssociate(id: number) {
     const url: string = this.baseURL + '/' + id;
-    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByUserId$.next(data));
+    this.http.get<Associate>(url).subscribe(
+      (data: Associate) => this.associateByUserId$.next(data),
+      error => this.associateByUserId$.error(error)
+    );
     return this.associateByUserId$;
   }
 
@@ -102,7 +113,10 @@ export class AssociateService {
    */
   getByAssociateId(id: number) {
     const url: string = this.baseURL + '/associates/' + id;
-    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByAssociateId$.next(data));
+    this.http.get<Associate>(url).subscribe(
+      (data: Associate) => this.associateByAssociateId$.next(data),
+      error => this.associateByAssociateId$.error(error)
+    );
     return this.associateByAssociateId$;
   }
 
@@ -136,7 +150,11 @@ export class AssociateService {
    */
   updateAssociate(associate: any) {
     const url: string = this.baseURL + '/' + associate.id;
-    return this.http.put<boolean>(url, associate);
+    this.http.put<boolean>(url, associate).subscribe(
+      data => this.updateAssociate$.next(data),
+      error => this.updateAssociate$.error(error)
+    );
+    return this.updateAssociate$;
   }
 
   getAssociatesByStatus(statusId: number): Observable<GraphCounts[]> {

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -36,7 +36,16 @@ export class AssociateService {
   private associateCount: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
 
   // TODO: Decide if empty strings is better or if a loading message should be put here
-  private currentAssociate: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
+  // TODO: Why is there a get by user and get by associate this is two different models on backend
+  // ? should one be handled by another service
+  // ? Do we really need two in this section of the frontend
+  private associateByUserId: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
+    "",
+    "",
+    null
+  ));
+
+  private associateByAssociateId: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
     "",
     "",
     null
@@ -81,8 +90,8 @@ export class AssociateService {
    */
   getAssociate(id: number) {
     const url: string = this.baseURL + '/' + id;
-    this.http.get<Associate>(url).subscribe((data: Associate) => this.currentAssociate.next(data));
-    return this.currentAssociate;
+    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByUserId.next(data));
+    return this.associateByUserId;
   }
 
   /**
@@ -92,7 +101,8 @@ export class AssociateService {
    */
   getByAssociateId(id: number) {
     const url: string = this.baseURL + '/associates/' + id;
-    return this.http.get<Associate>(url);
+    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByAssociateId.next(data));
+    return this.associateByAssociateId;
   }
 
   /**

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -17,10 +17,10 @@ export class AssociateService {
   private nassURL: string = this.baseURL + '/nass';
 
   /**
-   * This behavior subject will hold an initial empty value until a request is sent for associates
-   * The boolean will track if the first set of data is ready. This should not be the way it is
-   * implemented however since we have to remain compatible with the components written already
-   * sending a null value from an AsyncSubject would throw many errors
+   * These behavior subjects will hold an initial empty value until a request is sent for their
+   * data. The boolean will track if the first set of data is ready. This should not be the way
+   * it is implemented however since we have to remain compatible with the components written
+   * already sending a null value from an AsyncSubject would throw many errors
    *
    * TODO: Stop using the boolean and switch to using an AsyncSubject
    *
@@ -31,6 +31,8 @@ export class AssociateService {
    *    events that a subject will output when subscribed to
    */
   private allAssociates: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
+
+  private associateCount: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
 
   constructor(private http: HttpClient) {}
 
@@ -58,9 +60,10 @@ export class AssociateService {
   /**
    * get the count of the associates to display in the pie charts on the home page
    */
-  getCountAssociates(): Observable<number[]> {
+  getCountAssociates(): BehaviorSubject<number[]> {
     const url: string = this.baseURL + '/countAssociates';
-    return this.http.get<number[]>(url);
+    this.http.get<number[]>(url).subscribe((data: number[]) => this.associateCount.next(data));
+    return this.associateCount;
   }
 
   /**

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -1,3 +1,4 @@
+import { Associate } from './../../models/associate.model';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, AsyncSubject, BehaviorSubject } from 'rxjs';
@@ -33,6 +34,13 @@ export class AssociateService {
   private allAssociates: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
 
   private associateCount: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
+
+  // TODO: Decide if empty strings is better or if a loading message should be put here
+  private currentAssociate: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
+    "",
+    "",
+    null
+  ));
 
   constructor(private http: HttpClient) {}
 
@@ -73,7 +81,8 @@ export class AssociateService {
    */
   getAssociate(id: number) {
     const url: string = this.baseURL + '/' + id;
-    return this.http.get<Associate>(url);
+    this.http.get<Associate>(url).subscribe((data: Associate) => this.currentAssociate.next(data));
+    return this.currentAssociate;
   }
 
   /**

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -18,6 +18,17 @@ export class AssociateService {
 
   /**
    * This behavior subject will hold an initial empty value until a request is sent for associates
+   * The boolean will track if the first set of data is ready. This should not be the way it is
+   * implemented however since we have to remain compatible with the components written already
+   * sending a null value from an AsyncSubject would throw many errors
+   *
+   * TODO: Stop using the boolean and switch to using an AsyncSubject
+   *
+   * Note on things to do that would then allow this
+   * 1. In the dependant components null checking will be needed
+   * 2. Once components can handle a null value switch the BehaviorSubject to an Async Subject
+   * 3. Ideally the components will show loading, error, and success by listening to the three
+   *    events that a subject will output when subscribed to
    */
   private allAssociates: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
 
@@ -37,8 +48,8 @@ export class AssociateService {
     gets initial associates loaded
 
     ! DEPRECATED: This is not a good idea to try to speed up performance
-    ! the plan will be to implement pagination for now the app will just 
-    ! wait for all associates as this request will end up taking just as 
+    ! the plan will be to implement pagination for now the app will just
+    ! wait for all associates as this request will end up taking just as
     ! long due to the problems on the server side
   */
   getNAssociates(): Observable<Associate[]> {

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -34,6 +34,8 @@ export class AssociateService {
 
   private associateCount$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
 
+  private updateAssociates$: AsyncSubject<boolean> = new AsyncSubject<boolean>();
+
   // TODO: Decide if empty strings is better or if a loading message should be put here
   // TODO: Why is there a get by user and get by associate this is two different models on backend
   // ? should one be handled by another service
@@ -110,10 +112,21 @@ export class AssociateService {
    * @param ids - list of associate ids of associates to be updated
    * @param marketingStatusId - the marketing status these associates will be updated to
    * @param clientId - the client id that the associates will be mapped to
+   * 
+   * ? Changing this to use BehaviorSubjects however it may be wanted to have it not multiplex
    */
   updateAssociates(ids: number[], verification: number, marketingStatusId: number, clientId: number): Observable<boolean> {
     const url: string = this.baseURL + '?marketingStatusId=' + marketingStatusId + '&clientId=' + clientId + '&verification=' + verification;
-    return this.http.put<boolean>(url, ids);
+    this.http.put<boolean>(url, ids).subscribe(
+      (data) => {
+        this.updateAssociates$.next(data);
+      },
+      (error) => {
+        this.updateAssociates$.error(error);
+      }
+    );
+
+    return  this.updateAssociates$;
   }
 
   /**

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -1,4 +1,3 @@
-import { Associate } from './../../models/associate.model';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, AsyncSubject, BehaviorSubject } from 'rxjs';
@@ -31,21 +30,21 @@ export class AssociateService {
    * 3. Ideally the components will show loading, error, and success by listening to the three
    *    events that a subject will output when subscribed to
    */
-  private allAssociates: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
+  private allAssociates$: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
 
-  private associateCount: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
+  private associateCount$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
 
   // TODO: Decide if empty strings is better or if a loading message should be put here
   // TODO: Why is there a get by user and get by associate this is two different models on backend
   // ? should one be handled by another service
   // ? Do we really need two in this section of the frontend
-  private associateByUserId: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
+  private associateByUserId$: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
     "",
     "",
     null
   ));
 
-  private associateByAssociateId: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
+  private associateByAssociateId$: BehaviorSubject<Associate> = new BehaviorSubject<Associate>(new Associate(
     "",
     "",
     null
@@ -59,8 +58,8 @@ export class AssociateService {
    */
   getAllAssociates(): BehaviorSubject<Associate[]> {
     const url: string = this.baseURL + '/allAssociates';
-    this.http.get<Associate[]>(url).subscribe((data: Associate[]) => this.allAssociates.next(data));
-    return this.allAssociates;
+    this.http.get<Associate[]>(url).subscribe((data: Associate[]) => this.allAssociates$.next(data));
+    return this.allAssociates$;
   }
 
   /*
@@ -79,8 +78,8 @@ export class AssociateService {
    */
   getCountAssociates(): BehaviorSubject<number[]> {
     const url: string = this.baseURL + '/countAssociates';
-    this.http.get<number[]>(url).subscribe((data: number[]) => this.associateCount.next(data));
-    return this.associateCount;
+    this.http.get<number[]>(url).subscribe((data: number[]) => this.associateCount$.next(data));
+    return this.associateCount$;
   }
 
   /**
@@ -90,8 +89,8 @@ export class AssociateService {
    */
   getAssociate(id: number) {
     const url: string = this.baseURL + '/' + id;
-    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByUserId.next(data));
-    return this.associateByUserId;
+    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByUserId$.next(data));
+    return this.associateByUserId$;
   }
 
   /**
@@ -101,8 +100,8 @@ export class AssociateService {
    */
   getByAssociateId(id: number) {
     const url: string = this.baseURL + '/associates/' + id;
-    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByAssociateId.next(data));
-    return this.associateByAssociateId;
+    this.http.get<Associate>(url).subscribe((data: Associate) => this.associateByAssociateId$.next(data));
+    return this.associateByAssociateId$;
   }
 
   /**

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, AsyncSubject, BehaviorSubject } from 'rxjs';
 
 import { Associate } from '../../models/associate.model';
 import { environment } from '../../../environments/environment';
@@ -15,19 +15,31 @@ import { GraphCounts } from '../../models/graph-counts';
 export class AssociateService {
   private baseURL: string = environment.url + 'TrackForce/associates';
   private nassURL: string = this.baseURL + '/nass';
+
+  /**
+   * This behavior subject will hold an initial empty value until a request is sent for associates
+   */
+  private allAssociates: BehaviorSubject<Associate[]> = new BehaviorSubject<Associate[]>([]);
+
   constructor(private http: HttpClient) {}
 
   /**
    *
    * Gets all of the associates
    */
-  getAllAssociates(): Observable<Associate[]> {
+  getAllAssociates(): BehaviorSubject<Associate[]> {
     const url: string = this.baseURL + '/allAssociates';
-    return this.http.get<Associate[]>(url);
+    this.http.get<Associate[]>(url).subscribe((data: Associate[]) => this.allAssociates.next(data));
+    return this.allAssociates;
   }
 
   /*
     gets initial associates loaded
+
+    ! DEPRECATED: This is not a good idea to try to speed up performance
+    ! the plan will be to implement pagination for now the app will just 
+    ! wait for all associates as this request will end up taking just as 
+    ! long due to the problems on the server side
   */
   getNAssociates(): Observable<Associate[]> {
     return this.http.get<Associate[]>(this.nassURL);

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -18,11 +18,17 @@ export class AssociateService {
 
   /**
    * These behavior subjects will hold an initial empty value until a request is sent for their
-   * data. The boolean will track if the first set of data is ready. This should not be the way
-   * it is implemented however since we have to remain compatible with the components written
-   * already sending a null value from an AsyncSubject would throw many errors
+   * data. This should not be the way it is implemented however since we have to remain compatible 
+   * with the components written already sending a null value from an AsyncSubject would throw many errors
    *
-   * TODO: Stop using the boolean and switch to using an AsyncSubject
+   * Each of the private variables below represents the return of each of the functions that are in this
+   * service this needs to be refactored but in this first pass of the service revamp top priority is to
+   * stop having the data reload each time and allow the application to hold a copy of the data to load
+   * then update in the background.
+   * 
+   * NOTE: The $ on a variable mean it is an Observable
+   * 
+   * TODO: switch to using an AsyncSubject
    *
    * Note on things to do that would then allow this
    * 1. In the dependant components null checking will be needed
@@ -149,6 +155,7 @@ export class AssociateService {
     return  this.updateAssociates$;
   }
 
+  
   /**
    *
    * This method updates the associate in the database
@@ -162,6 +169,10 @@ export class AssociateService {
     );
     return this.updateAssociate$;
   }
+
+  // ? Below this point the requests are for stats which may need to become a seperate service
+  // For now that decision can be left to the service revamp for now the service update will
+  // focus on keeping one copy of data to aid performance
 
   getAssociatesByStatus(statusId: number): Observable<GraphCounts[]> {
     this.http.get<GraphCounts[]>(this.baseURL + '/mapped/' + statusId).subscribe(

--- a/NGTrackForce/src/app/services/associate-service/associate.service.ts
+++ b/NGTrackForce/src/app/services/associate-service/associate.service.ts
@@ -38,6 +38,12 @@ export class AssociateService {
 
   private updateAssociate$: AsyncSubject<boolean> = new AsyncSubject<boolean>();
 
+  private approveAssociate$: AsyncSubject<boolean> = new AsyncSubject<boolean>();
+
+  private getAssociatesByStatus$: AsyncSubject<GraphCounts[]> = new AsyncSubject<GraphCounts[]>();
+
+  private getUndeployedAssociates$: AsyncSubject<GraphCounts[]> = new AsyncSubject<GraphCounts[]>();
+
   // TODO: Decide if empty strings is better or if a loading message should be put here
   // TODO: Why is there a get by user and get by associate this is two different models on backend
   // ? should one be handled by another service
@@ -158,16 +164,28 @@ export class AssociateService {
   }
 
   getAssociatesByStatus(statusId: number): Observable<GraphCounts[]> {
-    return this.http.get<GraphCounts[]>(this.baseURL + '/mapped/' + statusId);
+    this.http.get<GraphCounts[]>(this.baseURL + '/mapped/' + statusId).subscribe(
+      (data: GraphCounts[]) => this.getAssociatesByStatus$.next(data),
+      error => this.getAssociatesByStatus$.error(error)
+    );
+    return this.getAssociatesByStatus$;
   }
 
   approveAssociate(associateID: number) {
     const url: string = this.baseURL + '/' + associateID + '/approve';
-    return this.http.put<boolean>(url, associateID);
+    this.http.put<boolean>(url, associateID).subscribe(
+      data => this.approveAssociate$.next(data),
+      error => this.approveAssociate$.error(error)
+    );
+    return  this.approveAssociate$;
   }
 
   getUndeployedAssociates(mappedOrUnmapped: string): Observable<GraphCounts[]> {
     const url: string = this.baseURL + '/undeployed/' + mappedOrUnmapped;
-    return this.http.get<GraphCounts[]>(url);
+    this.http.get<GraphCounts[]>(url).subscribe(
+      (data: GraphCounts[]) => this.getUndeployedAssociates$.next(data),
+      error => this.getUndeployedAssociates$.error(error)
+    );
+    return this.getUndeployedAssociates$;
   }
 }


### PR DESCRIPTION
This PR redesigns the associate service to resolve #700. Now the data will be held and not cleared out each time the associate information is requested. After the first load of associate information the application will be able to load on the data instantly.

NOTE: because the entire associate list is being pulled in at once the render time for this is rather high

*There is a change in the query strategy coming but is not implemented yet*