### PR TITLE
Fixed the problem of interview page not loading

### DIFF
--- a/NGTrackForce/src/app/components/myinterview-view/myinterview-view.component.ts
+++ b/NGTrackForce/src/app/components/myinterview-view/myinterview-view.component.ts
@@ -152,7 +152,7 @@ export class MyInterviewComponent implements OnInit {
         ).getTime();
         this.interviewService.updateInterview(interview).subscribe(res => {
           this.updateSuccess=true;
-    //      location.reload();
+          location.reload();
         });
     }
   }


### PR DESCRIPTION
**Bug**
 Interview page could not be loaded from the associate page
**Solution**
Put the option of re-loading the page back after updating the interview dates