### PR TITLE
UI and bug update on interview-details component

### DIFF
--- a/NGTrackForce/src/app/components/interview-details/interview-details.component.html
+++ b/NGTrackForce/src/app/components/interview-details/interview-details.component.html
@@ -25,8 +25,8 @@
 
 	<div class="container-fluid">
 		<div class="row"*ngIf="promptToggle">
-			<div class={{promptClassName}} role="alert">
-				{{promptMessage}}
+			<div class="col-sm-4 alert" role="alert" [ngClass]="promptClassName">
+				{{ promptMessage }}
 			</div>
 		</div>
 		<div class="row">
@@ -34,7 +34,11 @@
 				<button type="button" [routerLink]="['/myinterview-view']" class="btn btn-primary">Close</button>
 			</div>
 			<div class="col-sm-2">
-				<button class="btn btn-primary" type="button" (click)="commitchanges()">
+        <button
+          class="btn btn-primary"
+          type="button"
+          [disabled]="serverResponsePending"
+          (click)="commitchanges()">
 					Save Changes
 				</button>
 			</div>

--- a/NGTrackForce/src/app/components/interview-details/interview-details.component.ts
+++ b/NGTrackForce/src/app/components/interview-details/interview-details.component.ts
@@ -7,6 +7,7 @@ import { AuthenticationService } from '../../services/authentication-service/aut
 import { Associate } from '../../models/associate.model';
 import { Interview } from '../../models/interview.model';
 import { User } from '../../models/user.model';
+import { InterviewUpdate, PromptClass } from './interview-details.enum';
 
 @Component({
   selector: 'app-interview-details',
@@ -20,8 +21,9 @@ export class InterviewDetailsComponent implements OnInit {
   public associate: Associate;
   isDataReady: boolean;
   isDataEmpty: boolean;
-  promptClassName = "col-sm-4 alert alert-success";
-  promptMessage = "Succes-interview updated";
+  serverResponsePending = false;
+  promptClassName = "alert-success";
+  promptMessage: InterviewUpdate;
   promptToggle = false;
   isDisabledAssociate = false;
   isDisabledClient = false;
@@ -46,26 +48,31 @@ export class InterviewDetailsComponent implements OnInit {
     });
   }
 
-  commitchanges()
-  {
-    this.promptToggle = false;
+  private _displayPrompt(
+    serverResponsePending: boolean,
+    promptClass: PromptClass,
+    message: InterviewUpdate) {
+
+      this.serverResponsePending = serverResponsePending;
+      this.promptClassName = promptClass;
+      this.promptMessage = message;
+      this.promptToggle = true;
+  }
+
+  commitchanges() {
+    this._displayPrompt(true, PromptClass.WAIT, InterviewUpdate.WAIT);
     this.interviewService.updateInterview(this.interview).subscribe(
       response => {
-        this.promptClassName = "col-sm-4 alert alert-success";
-        this.promptMessage = "Success-interview updated";
-        this.promptToggle = true;
+        this._displayPrompt(false, PromptClass.SUCCESS, InterviewUpdate.SUCCESS);
       },
       error => {
-        this.promptClassName = "col-sm-4 alert alert-danger";
-        this.promptMessage = "Failed-interview not updated";
-        this.promptToggle = true;
-        console.log("Error: ",error);
+        this._displayPrompt(false, PromptClass.FAILURE, InterviewUpdate.FAILURE);
+        console.error(error);
       }
     );
   }
 
-  isDisabledAssociateFeedback()
-  {
+  isDisabledAssociateFeedback() {
     this.user = this.authService.getUser();
     if ( this.user.role === 3 )
     {
@@ -78,8 +85,7 @@ export class InterviewDetailsComponent implements OnInit {
     return this.isDisabledAssociate;
   }
 
-  isDisabledClientFeedback()
-  {
+  isDisabledClientFeedback() {
     this.user = this.authService.getUser();
     if ( this.user.role === 3 )
     {
@@ -92,8 +98,7 @@ export class InterviewDetailsComponent implements OnInit {
     return this.isDisabledClient;
   }
 
-  isDisabledInterviewQuestions()
-  {
+  isDisabledInterviewQuestions() {
     this.user = this.authService.getUser();
     if ( this.user.role === 3 )
     {
@@ -106,8 +111,7 @@ export class InterviewDetailsComponent implements OnInit {
     return this.isDisabledQuestions;
   }
 
-  isDisabledExpectedSkillsAndQuestions()
-  {
+  isDisabledExpectedSkillsAndQuestions() {
     this.user = this.authService.getUser();
     if ( this.user.role === 3 )
     {

--- a/NGTrackForce/src/app/components/interview-details/interview-details.enum.ts
+++ b/NGTrackForce/src/app/components/interview-details/interview-details.enum.ts
@@ -1,0 +1,11 @@
+export enum InterviewUpdate {
+  SUCCESS = "Success!  Your interview was updated",
+  WAIT = "Please wait, your changes are pending",
+  FAILURE = "An error occured on the server, your interview was not updated"
+}
+
+export enum PromptClass {
+  SUCCESS = 'alert-success',
+  WAIT = 'alert-warning',
+  FAILURE = 'alert-danger',
+}

--- a/NGTrackForce/src/app/services/interview-service/interview.service.ts
+++ b/NGTrackForce/src/app/services/interview-service/interview.service.ts
@@ -63,7 +63,6 @@ y
    */
   public updateInterview(interview: Interview): Observable<boolean> {
     const url: string = this.baseURL + "/" + interview.id;
-    // console.log("asdf");
     return this.http.put<boolean>(url, interview);
   }
 }


### PR DESCRIPTION
User is now informed to wait for server response when he submits details about his interview.  Submit button is disabled to avoid spamming until the server responds.  Refactored code to be more type safe and DRY.