### PR TITLE
Issue #947 and Issue #948

### DIFF
--- a/NGTrackForce/src/app/components/batch-list/batch-list.component.ts
+++ b/NGTrackForce/src/app/components/batch-list/batch-list.component.ts
@@ -77,7 +77,6 @@ export class BatchListComponent implements OnInit {
   ngOnInit() {
     if(this.authService.getUserRole() == 2 &&
       (!this.authService.getTrainer() || this.authService.getTrainer() == null)){
-      // Can be removed once the guard is asynchronous
       this.dataReady = true;
       return;
     }

--- a/NGTrackForce/src/app/components/batch-list/batch-list.component.ts
+++ b/NGTrackForce/src/app/components/batch-list/batch-list.component.ts
@@ -75,6 +75,12 @@ export class BatchListComponent implements OnInit {
    * load default batches on initialization
    */
   ngOnInit() {
+    if(this.authService.getUserRole() == 2 &&
+      (!this.authService.getTrainer() || this.authService.getTrainer() == null)){
+      // Can be removed once the guard is asynchronous
+      this.dataReady = true;
+      return;
+    }
     // get current user
     const user = this.authService.getUser();
     this.dataReady = false;
@@ -88,14 +94,6 @@ export class BatchListComponent implements OnInit {
     console.log(user);
     this.batchService.getBatchesWithinDates(this.startDate,this.endDate).subscribe(
       batches => {
-				// This condition should be at the begining of the init method
-				// but since the auth guard isn't asynchronous yet it has to be for now
-				if(this.authService.getUserRole() == 2 &&
-					(!this.authService.getTrainer() || this.authService.getTrainer() == null)){
-					// Can be removed once the guard is asynchronous
-					this.dataReady = true;
-					return;
-				}
         this.batches = batches.filter(
           batch => {
 

--- a/NGTrackForce/src/app/guards/auth.guard.ts
+++ b/NGTrackForce/src/app/guards/auth.guard.ts
@@ -16,7 +16,7 @@ export class AuthGuard implements CanActivate {
 	 *  Responsible for redirecting the user to the login page, and maintaining the state of their original request, which,
 	 *  when they log in, should be redirected to.
 	 */
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
         console.log("In AuthGuard Outer")
 
         // not logged in so redirect to login page with the return url
@@ -36,14 +36,13 @@ export class AuthGuard implements CanActivate {
             const user = this.authService.getUser();
             console.log("in AuthGuard Inner");
             if (this.authService.getUserRole() === undefined) {
-                this.authService.getUserRoleFirst();
+                await this.authService.getUserRoleFirst((UserRole) => {
+                    if (!expectedRoles.includes(UserRole)) {
+                        this.routeToUserHome(UserRole);
+                        return false;
+                    }
+                });
             }
-            setTimeout(() => {
-                if (!expectedRoles.includes(this.authService.getUserRole())) {
-                    this.routeToUserHome(this.authService.getUserRole());
-                    return false;
-                }
-            }, 10);
         }
 
         return true;

--- a/NGTrackForce/src/app/guards/auth.guard.ts
+++ b/NGTrackForce/src/app/guards/auth.guard.ts
@@ -37,11 +37,11 @@ export class AuthGuard implements CanActivate {
             console.log("in AuthGuard Inner");
             if (this.authService.getUserRole() === undefined) {
                 await this.authService.getUserRoleFirst((UserRole) => {
-                    if (!expectedRoles.includes(UserRole)) {
-                        this.routeToUserHome(UserRole);
-                        return false;
-                    }
-                });
+                  if (!expectedRoles.includes(UserRole)) {
+                    this.routeToUserHome(UserRole);
+                    return false;
+                  }
+              });
             }
         }
 

--- a/NGTrackForce/src/app/services/authentication-service/authentication.service.ts
+++ b/NGTrackForce/src/app/services/authentication-service/authentication.service.ts
@@ -81,13 +81,12 @@ export class AuthenticationService {
         return this.role;
     }
 
-    getUserRoleFirst(callback = undefined) {
-        return this.http.get<number>(environment.url + "TrackForce/users/getUserRole").subscribe(data => {
-            this.role = data;
-            if(callback){
-              callback(data);
-            }
-        }, err => err);
+    async getUserRoleFirst(callback = undefined) {
+      this.role = await this.http.get<number>(environment.url + "TrackForce/users/getUserRole").toPromise();
+      if(callback){
+        callback(this.role);
+      }
+      return this.role;
     }
 
     /**


### PR DESCRIPTION
The problem was the auth guard fetches the user role is sync manner so that leads to other pages that needs that user role throwing errors because it's not there when they needed it like batch-list

Now  that the auth guard acts in a async manner just as the fetch getUser function it's guaranteed that the user role would be available when it's needed

Issue #947 is the main issue but it's accompanied with #948 to be able to visualized the problem

testing it as far as I know is before the fix when you go to the batch-list for  trainer which his user name and password are "trainer" the site would try and fetch the data even if he's not allowed to and once the data is fetched it's decided not to show any of them but after the fix the request won't be even sent and stops the whole process from the start