### PR TITLE
add a contextListener issues #687 and #930

### DIFF
--- a/TrackForce/src/main/java/com/revature/utils/ContextListener.java
+++ b/TrackForce/src/main/java/com/revature/utils/ContextListener.java
@@ -1,0 +1,33 @@
+package com.revature.utils;
+
+import java.sql.SQLException;
+import java.util.Set;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import com.mchange.v2.c3p0.C3P0Registry;
+import com.mchange.v2.c3p0.PooledDataSource;
+
+public class ContextListener implements ServletContextListener {
+	@Override
+	public void contextInitialized(ServletContextEvent servletContextEvent) {
+		HibernateUtil.getSessionFactory();
+	}
+
+	@Override
+	public void contextDestroyed(ServletContextEvent servletContextEvent) {
+		@SuppressWarnings("unchecked")
+		Set<PooledDataSource> pooledDataSourceSet = (Set<PooledDataSource>) C3P0Registry.getPooledDataSources();
+
+		for (PooledDataSource dataSource : pooledDataSourceSet) {
+			try {
+				dataSource.hardReset();
+				dataSource.close();
+			} catch (SQLException e) {
+				// note - do not use log4j since it may have been unloaded by this point
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/TrackForce/src/main/webapp/WEB-INF/web.xml
+++ b/TrackForce/src/main/webapp/WEB-INF/web.xml
@@ -69,5 +69,9 @@
     <filter-name>CorsFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
-
+<listener>  
+    <listener-class>
+        com.revature.utils.ContextListener
+    </listener-class>
+</listener> 
 </web-app>


### PR DESCRIPTION
add a contextListener that starts when the server starts and destroys… with it.

This pull request is for issues #687  and #930 Which I'm 90% sure they're the same issue

And added in the destroy method code to force turning off the hibernate resources in order to prevent memory leak Exception:
`C3P0PooledConnectionPoolManager`

and in addition to that I added `export JAVA_OPTS="-Dfile.encoding=UTF-8 -Xms128m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=256m"
` in $CATALINA_HOME/bin/setenv.sh in order to increase the memory used and also used as way to prevent memory leak

Signed-off-by: Mussab ElDash <mussab14@gmail.com>